### PR TITLE
Fix 40 wiki documentation discrepancies to match actual code API

### DIFF
--- a/wiki/Advanced-Completions.md
+++ b/wiki/Advanced-Completions.md
@@ -20,7 +20,7 @@ The simplest form: a static list of suggestions.
 ```java
 SlashCommand cmd = SlashCommand.create("setmode")
     .argStringWithCompletions("mode", "easy", "normal", "hard")
-    .executes(ctx -> { /* ... */ })
+    .executes((sender, ctx) -> { /* ... */ })
     .build();
 
 // Or using ArgContext builder:
@@ -28,7 +28,7 @@ SlashCommand cmd2 = SlashCommand.create("setmode")
     .argString("mode", ArgContext.builder()
         .withCompletions(List.of("easy", "normal", "hard"))
         .build())
-    .executes(ctx -> { /* ... */ })
+    .executes((sender, ctx) -> { /* ... */ })
     .build();
 ```
 
@@ -39,7 +39,7 @@ SlashCommand cmd = SlashCommand.create("setgame")
     .argString("game", ArgContext.builder()
         .completionsFromEnum(GameMode.class)
         .build())
-    .executes(ctx -> { /* ... */ })
+    .executes((sender, ctx) -> { /* ... */ })
     .build();
 ```
 
@@ -59,7 +59,7 @@ SlashCommand homes = SlashCommand.create("home")
             return homeService.getHomeNames(player);
         })
         .build())
-    .executes(ctx -> { /* teleport to home */ })
+    .executes((sender, ctx) -> { /* teleport to home */ })
     .build();
 ```
 
@@ -90,7 +90,7 @@ Generate completions based on previously parsed arguments:
 ArgContext ctx = ArgContext.builder()
     .completionsDynamic(DynamicCompletionProvider.contextBased(dynCtx -> {
         // Access previously parsed arguments
-        String category = dynCtx.getParsedArgument("category", String.class);
+        String category = (String) dynCtx.parsedArgsSoFar().get("category");
         if ("weapons".equals(category)) {
             return List.of("sword", "bow", "axe");
         } else if ("armor".equals(category)) {
@@ -134,7 +134,7 @@ SlashCommand search = SlashCommand.create("search")
             return database.getRecentSearches(player.getUniqueId());
         }))
         .build())
-    .executes(ctx -> { /* ... */ })
+    .executes((sender, ctx) -> { /* ... */ })
     .build();
 ```
 
@@ -171,7 +171,7 @@ SlashCommand regions = SlashCommand.create("region")
             return regionManager.getAllRegionNames();
         }))
         .build())
-    .executes(ctx -> { /* ... */ })
+    .executes((sender, ctx) -> { /* ... */ })
     .build();
 ```
 
@@ -252,7 +252,7 @@ SlashCommand shop = SlashCommand.create("shop")
         .build())
     .argString("item", ArgContext.builder()
         .completionsDynamic(DynamicCompletionProvider.contextBased(ctx -> {
-            String category = ctx.getParsedArgument("category", String.class);
+            String category = (String) ctx.parsedArgsSoFar().get("category");
             return shopService.getItemsInCategory(category);
         }))
         .build())
@@ -331,7 +331,7 @@ SlashCommand homes = SlashCommand.create("home")
             });
         })
         .build())
-    .executes(ctx -> { /* ... */ })
+    .executes((sender, ctx) -> { /* ... */ })
     .build();
 ```
 

--- a/wiki/Arguments.md
+++ b/wiki/Arguments.md
@@ -18,7 +18,7 @@ Example:
 SlashCommand tp = SlashCommand.create("tp")
     .argPlayer("target")
     .argWorld("world")
-    .executes(ctx -> {
+    .executes((sender, ctx) -> {
         Player target = ctx.get("target", Player.class);
         World world = ctx.get("world", World.class);
         // ... teleport logic
@@ -51,7 +51,7 @@ levels.put("hard", 3);
 
 SlashCommand set = SlashCommand.create("setdifficulty")
     .argChoices("mode", levels, "difficulty")
-    .executes(ctx -> {
+    .executes((sender, ctx) -> {
         int level = ctx.get("mode", Integer.class);
         // apply difficulty level
     })
@@ -234,7 +234,7 @@ SlashCommand give = SlashCommand.create("give")
     .argMaterial("item")
     .argIf("amount", ArgParsers.INT, ctx -> ctx.getFlag("bulk"))
     .flagLong("bulk", "bulk")
-    .executes(ctx -> {
+    .executes((sender, ctx) -> {
         int amount = ctx.getOrDefault("amount", Integer.class, 1);
         // ...
     })
@@ -296,7 +296,7 @@ Use `arg(name, ArgumentParser<T> parser)` to plug your own parser. Combine with 
 ```java
 SlashCommand custom = SlashCommand.create("custom")
     .arg("color", ArgParsers.enumParser(ChatColor.class))
-    .executes(ctx -> {
+    .executes((sender, ctx) -> {
         ChatColor c = ctx.get("color", ChatColor.class);
     })
     .build();
@@ -362,11 +362,11 @@ Using the fluent Arg API:
 
 ```java
 SlashCommand cmd = SlashCommand.create("give")
-    .arg(Arg.of("player", ArgParsers.PLAYER)
-        .withAliases("p", "target"))
-    .arg(Arg.of("amount", ArgParsers.INT)
-        .withAlias("amt")
-        .withAlias("n"))
+    .arg(new Arg<>("player", ArgParsers.PLAYER, ArgContext.builder()
+        .withAliases("p", "target").build()))
+    .arg(new Arg<>("amount", ArgParsers.INT, ArgContext.builder()
+        .addAlias("amt")
+        .addAlias("n").build()))
     .executes((sender, ctx) -> {
         // Access by alias
         Player p = ctx.get("p", Player.class);
@@ -414,8 +414,8 @@ Or using the fluent Arg API:
 
 ```java
 SlashCommand ban = SlashCommand.create("ban")
-    .argPlayer("target").withDescription("The player to ban")
-    .argString("reason").optional(true).withDescription("Reason for the ban")
+    .arg(new Arg<>("target", ArgParsers.playerParser(), ArgContext.builder().description("The player to ban").build()))
+    .arg(new Arg<>("reason", ArgParsers.stringParser(), ArgContext.builder().optional(true).description("Reason for the ban").build()))
     .executes((sender, ctx) -> { /* ... */ })
     .build();
 ```
@@ -492,8 +492,9 @@ For complex validation logic beyond simple ranges and patterns, use custom valid
 ##### Validator Interface
 
 ```java
+// Validator is a nested interface inside ArgContext
 @FunctionalInterface
-public interface Validator<T> {
+public interface ArgContext.Validator<T> {
     /**
      * @param value the value to validate
      * @return null if valid, or an error message if invalid
@@ -506,7 +507,7 @@ public interface Validator<T> {
 
 ```java
 // Validate username format
-Validator<String> usernameValidator = value -> {
+ArgContext.Validator<String> usernameValidator = value -> {
     if (value == null || value.isEmpty()) {
         return "Username cannot be empty";
     }
@@ -529,7 +530,7 @@ SlashCommand register = SlashCommand.create("register")
     .argString("username", ArgContext.builder()
         .addValidator(usernameValidator)
         .build())
-    .executes(ctx -> { /* ... */ })
+    .executes((sender, ctx) -> { /* ... */ })
     .build();
 ```
 
@@ -538,13 +539,13 @@ SlashCommand register = SlashCommand.create("register")
 You can chain multiple validators — they run in order, and the first error stops validation:
 
 ```java
-Validator<Integer> positiveValidator = value ->
+ArgContext.Validator<Integer> positiveValidator = value ->
     value == null || value <= 0 ? "Value must be positive" : null;
 
-Validator<Integer> evenValidator = value ->
+ArgContext.Validator<Integer> evenValidator = value ->
     value != null && value % 2 != 0 ? "Value must be even" : null;
 
-Validator<Integer> maxValidator = value ->
+ArgContext.Validator<Integer> maxValidator = value ->
     value != null && value > 1000 ? "Value cannot exceed 1000" : null;
 
 ArgContext ctx = ArgContext.builder()
@@ -555,7 +556,7 @@ ArgContext ctx = ArgContext.builder()
 
 SlashCommand cmd = SlashCommand.create("setvalue")
     .argInt("value", ctx)
-    .executes(ctx -> { /* ... */ })
+    .executes((sender, ctx) -> { /* ... */ })
     .build();
 ```
 
@@ -564,7 +565,7 @@ SlashCommand cmd = SlashCommand.create("setvalue")
 **Email validator:**
 
 ```java
-Validator<String> emailValidator = value -> {
+ArgContext.Validator<String> emailValidator = value -> {
     if (value == null) return "Email is required";
     if (!value.contains("@") || !value.contains(".")) {
         return "Invalid email format";
@@ -576,7 +577,7 @@ Validator<String> emailValidator = value -> {
 **Price validator (positive, max 2 decimals):**
 
 ```java
-Validator<Double> priceValidator = value -> {
+ArgContext.Validator<Double> priceValidator = value -> {
     if (value == null || value < 0) {
         return "Price must be non-negative";
     }
@@ -592,7 +593,7 @@ Validator<Double> priceValidator = value -> {
 **Unique name validator (check database):**
 
 ```java
-Validator<String> uniqueNameValidator = value -> {
+ArgContext.Validator<String> uniqueNameValidator = value -> {
     if (value == null) return "Name is required";
     if (database.nameExists(value)) {
         return "This name is already taken";
@@ -604,7 +605,7 @@ Validator<String> uniqueNameValidator = value -> {
 **Date range validator:**
 
 ```java
-Validator<String> futureDateValidator = value -> {
+ArgContext.Validator<String> futureDateValidator = value -> {
     if (value == null) return "Date is required";
     try {
         LocalDate date = LocalDate.parse(value);

--- a/wiki/Async-Cooldowns.md
+++ b/wiki/Async-Cooldowns.md
@@ -15,9 +15,9 @@ With timeout:
 ```java
 SlashCommand heavy = SlashCommand.create("heavy")
     .async(true)
-    .executesAsync((ctx, progress, cancellation) -> {
-        // periodically check cancellation.isCancelled()
-        // report progress.set(percent) if desired
+    .executesAsync((sender, ctx, token, progress) -> {
+        // periodically check token.cancelled()
+        // report progress via progress.report("Working...")
         doHeavyWork();
     }, 15_000L) // 15 seconds timeout
     .build();
@@ -41,7 +41,7 @@ Example:
 SlashCommand locate = SlashCommand.create("locate")
     .perUserCooldown(5_000)  // 5s per user
     .perServerCooldown(1_000) // 1s globally
-    .executes(ctx -> { /* ... */ })
+    .executes((sender, ctx) -> { /* ... */ })
     .build();
 ```
 

--- a/wiki/Batch-Operations.md
+++ b/wiki/Batch-Operations.md
@@ -41,8 +41,8 @@ SlashCommand cmd = SlashCommand.create("kick")
         .maxBatchSize(50)           // Maximum targets allowed (default: 100)
         .parallel(true)             // Enable parallel execution (default: false)
         .continueOnFailure(true)    // Continue if some targets fail (default: true)
-        .showProgress(true)         // Show progress messages (default: false)
-        .timeout(30_000)            // Timeout in milliseconds (default: 60000)
+        .showProgress(true)         // Show progress messages (default: true)
+        .timeoutMillis(30_000)            // Timeout in milliseconds (default: 30000)
     )
     .batchAction((Player player, BatchContext<Player> ctx) -> {
         String reason = ctx.argString("reason", "No reason");
@@ -59,8 +59,8 @@ SlashCommand cmd = SlashCommand.create("kick")
 | `maxBatchSize` | int | 100 | Maximum number of targets allowed |
 | `parallel` | boolean | false | Execute actions concurrently |
 | `continueOnFailure` | boolean | true | Continue processing after failures |
-| `showProgress` | boolean | false | Send progress messages to sender |
-| `timeout` | long | 60000 | Maximum execution time in milliseconds |
+| `showProgress` | boolean | true | Send progress messages to sender |
+| `timeout` | long | 30000 | Maximum execution time in milliseconds |
 
 #### BatchContext API
 
@@ -133,7 +133,7 @@ When `parallel(true)` is configured, batch operations execute concurrently:
 ```java
 .batch("players", config -> config
     .parallel(true)
-    .maxParallelism(4)  // Limit concurrent threads
+    .parallelism(4)  // Limit concurrent threads
 )
 ```
 

--- a/wiki/Builder-API.md
+++ b/wiki/Builder-API.md
@@ -19,9 +19,9 @@ SlashCommand cmd = SlashCommand.create("greet")
     .aliases("hello", "hi")
     .playersOnly()
     .argPlayer("target")
-    .executes(ctx -> {
+    .executes((sender, ctx) -> {
         Player p = ctx.get("target", Player.class);
-        ctx.get("sender", CommandSender.class).sendMessage("Hello, " + p.getName());
+        sender.sendMessage("Hello, " + p.getName());
     })
     .build();
 
@@ -113,18 +113,17 @@ Retrieve at runtime via `CommandContext.getKeyValue*(...)` or `getKeyValue(name,
 
 #### Metrics
 
-- `enableMetrics(boolean)` — Enable execution metrics collection. Default: false.
+**Note:** `CommandMetrics` is available as a standalone utility class but is not currently wired into the builder API. Use `CommandMetrics` directly for custom metrics tracking.
 
-When enabled, access metrics via `SlashCommand.metrics()`:
+~~`enableMetrics(boolean)`~~ and ~~`SlashCommand.metrics()`~~ do not exist on the builder or `SlashCommand`. The example below shows the `CommandMetrics` API when used standalone:
 
 ```java
 SlashCommand cmd = SlashCommand.create("example")
-    .enableMetrics(true)
-    .executes(ctx -> { /* ... */ })
+    .executes((sender, ctx) -> { /* ... */ })
     .build();
 
-// Later, retrieve metrics
-CommandMetrics metrics = cmd.metrics();
+// Use CommandMetrics directly as a standalone utility
+CommandMetrics metrics = new CommandMetrics();
 
 // Get individual statistics
 long total = metrics.getTotalExecutions();
@@ -194,4 +193,4 @@ Argument groups are validated after parsing. See [Guards-Validation-Permissions]
 #### Produce & Register
 
 - `build()` — Produce an immutable `SlashCommand`.
-- `register(JavaPlugin plugin)` — Shortcut to build and register in one chain in some flows; typically call on the built `SlashCommand`.
+- `register(JavaPlugin plugin)` — Called on the built `SlashCommand` instance (not on the builder). Always call `build()` first, then `register(plugin)` on the resulting `SlashCommand`.

--- a/wiki/CommandContext-API.md
+++ b/wiki/CommandContext-API.md
@@ -380,9 +380,9 @@ SlashCommand.create("teleport")
         .build())
     .build();
 
-// Or using fluent API on Arg
-Arg<Player> playerArg = Arg.of("player", playerParser())
-    .withAliases("p", "target", "t");
+// Or using ArgContext aliases
+Arg<Player> playerArg = new Arg<>("player", playerParser(),
+        ArgContext.builder().aliases("p", "target", "t").build());
 ```
 
 ##### Using Aliases in CommandContext

--- a/wiki/Examples.md
+++ b/wiki/Examples.md
@@ -9,8 +9,8 @@ SlashCommand greet = SlashCommand.create("greet")
     .description("Greets the specified player")
     .playersOnly()
     .argPlayer("target")
-    .executes(ctx -> {
-        Player me = ctx.get("sender", Player.class);
+    .executes((sender, ctx) -> {
+        Player me = (Player) sender;
         Player target = ctx.get("target", Player.class);
         target.sendMessage("" + me.getName() + " says hi!");
     })
@@ -28,7 +28,7 @@ Guard maintenanceEnabled = new Guard() {
 SlashCommand kickAll = SlashCommand.create("kickall")
     .permission("leviathan.admin.kickall")
     .require(maintenanceEnabled)
-    .executes(ctx -> {
+    .executes((sender, ctx) -> {
         // kick logic
     })
     .build();
@@ -41,7 +41,7 @@ SlashCommand backup = SlashCommand.create("backup")
     .flag("verbose", 'v', "verbose")
     .keyValueString("target")
     .keyValueBoolean("compress", true)
-    .executes(ctx -> {
+    .executes((sender, ctx) -> {
         boolean verbose = ctx.getFlag("verbose");
         String target = ctx.getKeyValueString("target");
         boolean compress = ctx.getKeyValueBoolean("compress", true);
@@ -54,10 +54,10 @@ SlashCommand backup = SlashCommand.create("backup")
 
 ```java
 SlashCommand map = SlashCommand.create("map")
-    .executesAsync((ctx, progress, token) -> {
+    .executesAsync((sender, ctx, token, progress) -> {
         for (int i = 0; i <= 100; i++) {
-            if (token.isCancelled()) return; // stop early
-            progress.set(i);
+            if (token.cancelled()) return; // stop early
+            progress.report("Progress: " + i + "%");
             // do work chunk
         }
     }, 20_000L)
@@ -69,7 +69,7 @@ SlashCommand map = SlashCommand.create("map")
 ```java
 SlashCommand add = SlashCommand.create("add")
     .argInt("a").argInt("b")
-    .executes(ctx -> ctx.get("sender", CommandSender.class).sendMessage(
+    .executes((sender, ctx) -> sender.sendMessage(
         String.valueOf(ctx.get("a", Integer.class) + ctx.get("b", Integer.class))))
     .build();
 
@@ -85,13 +85,13 @@ SlashCommand math = SlashCommand.create("math")
 ```java
 SlashCommand list = SlashCommand.create("listitems")
     .argPage("page", 1)
-    .executes(ctx -> {
+    .executes((sender, ctx) -> {
         int page = ctx.get("page", Integer.class);
         List<String> items = itemService.list();
         PaginationDataSource<String> ds = new ListDataSource<>(items);
         PaginatedResult<String> result = ds.page(page, 10);
-        for (String s : result.items()) ctx.get("sender", CommandSender.class).sendMessage(s);
-        ctx.get("sender", CommandSender.class).sendMessage(
+        for (String s : result.items()) sender.sendMessage(s);
+        sender.sendMessage(
             "Page " + result.pageInfo().current() + "/" + result.pageInfo().total());
     })
     .build();
@@ -105,7 +105,7 @@ SlashCommand give = SlashCommand.create("give")
     .argPlayer("target")
     .argMaterial("item")
     .argIf("amount", ArgParsers.INT, ctx -> ctx.getFlag("bulk"))
-    .executes(ctx -> {
+    .executes((sender, ctx) -> {
         int amount = ctx.getOrDefault("amount", Integer.class, 1);
         // give item
     })
@@ -120,9 +120,9 @@ The `parent()` method allows a subcommand to register itself to a parent builder
 // Traditional approach: parent registers children
 SlashCommand add = SlashCommand.create("add")
     .argInt("a").argInt("b")
-    .executes(ctx -> {
+    .executes((sender, ctx) -> {
         int sum = ctx.get("a", Integer.class) + ctx.get("b", Integer.class);
-        ctx.get("sender", CommandSender.class).sendMessage("Sum: " + sum);
+        sender.sendMessage("Sum: " + sum);
     })
     .build();
 

--- a/wiki/Exceptions-ErrorHandling.md
+++ b/wiki/Exceptions-ErrorHandling.md
@@ -86,7 +86,7 @@ SuggestionEngine.Suggestion suggestion = SuggestionEngine.suggest(
     "input",           // User input
     options,           // Available options
     3,                 // Max suggestions to return
-    0.6                // Minimum similarity threshold (0.0-1.0)
+    0.4                // Minimum similarity threshold (0.0-1.0)
 );
 ```
 

--- a/wiki/Flags-KeyValues.md
+++ b/wiki/Flags-KeyValues.md
@@ -14,7 +14,7 @@ SlashCommand cmd = SlashCommand.create("backup")
     .flag("verbose", 'v', "verbose")
     .flagShort("dryrun", 'n')
     .flagLong("force", "force")
-    .executes(ctx -> {
+    .executes((sender, ctx) -> {
         boolean verbose = ctx.getFlag("verbose");
         boolean dry = ctx.getFlag("dryrun", false);
         boolean force = ctx.getFlag("force");
@@ -72,7 +72,7 @@ When `supportsNegation(true)` is set (the default), users can explicitly set a f
 // Command definition
 SlashCommand cmd = SlashCommand.create("backup")
     .flag("confirm", 'c', "confirm")  // Supports --no-confirm
-    .executes(ctx -> {
+    .executes((sender, ctx) -> {
         boolean confirm = ctx.getFlag("confirm");
         // confirm will be:
         // - false if neither --confirm nor --no-confirm provided
@@ -103,7 +103,7 @@ SlashCommand cmd = SlashCommand.create("search")
     .keyValueInt("limit", 25)
     .keyValueBoolean("caseSensitive", false)
     .keyValueEnum("mode", Mode.class, Mode.SMART)
-    .executes(ctx -> {
+    .executes((sender, ctx) -> {
         String q = ctx.getKeyValueString("query");
         int limit = ctx.getKeyValueInt("limit", 25);
         boolean cs = ctx.getKeyValueBoolean("caseSensitive", false);

--- a/wiki/Guards-Validation-Permissions.md
+++ b/wiki/Guards-Validation-Permissions.md
@@ -14,7 +14,7 @@ SlashCommand ban = SlashCommand.create("ban")
     .permission("leviathan.admin.ban")
     .argPlayer("target")
     .argString("reason")
-    .executes(ctx -> { /* ... */ })
+    .executes((sender, ctx) -> { /* ... */ })
     .build();
 ```
 
@@ -37,19 +37,19 @@ Builder helpers:
 // Single permission
 SlashCommand admin = SlashCommand.create("admin")
     .requirePermission("myplugin.admin")
-    .executes(ctx -> { /* ... */ })
+    .executes((sender, ctx) -> { /* ... */ })
     .build();
 
 // Any of multiple permissions (OR logic)
 SlashCommand moderate = SlashCommand.create("moderate")
     .requireAnyPermission("myplugin.admin", "myplugin.moderator", "myplugin.helper")
-    .executes(ctx -> { /* ... */ })
+    .executes((sender, ctx) -> { /* ... */ })
     .build();
 
 // All permissions required (AND logic)
 SlashCommand superadmin = SlashCommand.create("superadmin")
     .requireAllPermissions("myplugin.admin", "myplugin.superadmin")
-    .executes(ctx -> { /* ... */ })
+    .executes((sender, ctx) -> { /* ... */ })
     .build();
 ```
 
@@ -63,7 +63,7 @@ Guard onlyAtNight = new Guard() {
 
 SlashCommand howl = SlashCommand.create("howl")
     .require(onlyAtNight)
-    .executes(ctx -> { /* ... */ })
+    .executes((sender, ctx) -> { /* ... */ })
     .build();
 ```
 
@@ -80,7 +80,7 @@ MessageProvider messages = new DefaultMessageProvider();
 
 SlashCommand admin = SlashCommand.create("admin")
     .require(Guard.permission("myplugin.admin", messages))
-    .executes(ctx -> { /* ... */ })
+    .executes((sender, ctx) -> { /* ... */ })
     .build();
 ```
 
@@ -91,7 +91,7 @@ Restrict command to a specific world:
 ```java
 SlashCommand spawn = SlashCommand.create("spawn")
     .require(Guard.inWorld("world_spawn", messages))
-    .executes(ctx -> {
+    .executes((sender, ctx) -> {
         // Only works in world_spawn
     })
     .build();
@@ -104,7 +104,7 @@ Require a specific game mode:
 ```java
 SlashCommand creative = SlashCommand.create("fly")
     .require(Guard.inGameMode(GameMode.CREATIVE, messages))
-    .executes(ctx -> { /* ... */ })
+    .executes((sender, ctx) -> { /* ... */ })
     .build();
 ```
 
@@ -115,7 +115,7 @@ Restrict to server operators:
 ```java
 SlashCommand op = SlashCommand.create("opcommand")
     .require(Guard.opOnly(messages))
-    .executes(ctx -> { /* ... */ })
+    .executes((sender, ctx) -> { /* ... */ })
     .build();
 ```
 
@@ -127,13 +127,13 @@ Check player experience level:
 // Minimum level required
 SlashCommand enchant = SlashCommand.create("superenchant")
     .require(Guard.minLevel(30, messages))
-    .executes(ctx -> { /* ... */ })
+    .executes((sender, ctx) -> { /* ... */ })
     .build();
 
 // Level must be within range
 SlashCommand midgame = SlashCommand.create("midgame")
     .require(Guard.levelRange(10, 50, messages))
-    .executes(ctx -> { /* ... */ })
+    .executes((sender, ctx) -> { /* ... */ })
     .build();
 ```
 
@@ -144,7 +144,7 @@ Check player health:
 ```java
 SlashCommand risky = SlashCommand.create("risky")
     .require(Guard.healthAbove(10.0, messages))  // Must have > 10 health
-    .executes(ctx -> { /* ... */ })
+    .executes((sender, ctx) -> { /* ... */ })
     .build();
 ```
 
@@ -155,7 +155,7 @@ Check player hunger:
 ```java
 SlashCommand run = SlashCommand.create("sprint")
     .require(Guard.foodLevelAbove(6, messages))  // Must have > 6 food
-    .executes(ctx -> { /* ... */ })
+    .executes((sender, ctx) -> { /* ... */ })
     .build();
 ```
 
@@ -166,7 +166,7 @@ Check if player is flying:
 ```java
 SlashCommand aerial = SlashCommand.create("airstrike")
     .require(Guard.isFlying(messages))
-    .executes(ctx -> { /* ... */ })
+    .executes((sender, ctx) -> { /* ... */ })
     .build();
 ```
 
@@ -184,7 +184,7 @@ SlashCommand day = SlashCommand.create("sunpower")
         },
         "This command only works during daytime!"
     ))
-    .executes(ctx -> { /* ... */ })
+    .executes((sender, ctx) -> { /* ... */ })
     .build();
 ```
 
@@ -201,7 +201,7 @@ SlashCommand elite = SlashCommand.create("elite")
         Guard.minLevel(50, messages),
         Guard.healthAbove(15.0, messages)
     )
-    .executes(ctx -> {
+    .executes((sender, ctx) -> {
         // Player must:
         // 1. Have myplugin.elite permission
         // 2. Be in world_arena
@@ -523,9 +523,10 @@ SlashCommand range = SlashCommand.create("range")
     .addCrossArgumentValidator(ctx -> {
         int min = ctx.get("min", Integer.class);
         int max = ctx.get("max", Integer.class);
-        if (min > max) throw new IllegalArgumentException("min must be <= max");
+        if (min > max) return "min must be <= max";
+        return null;
     })
-    .executes(ctx -> { /* ... */ })
+    .executes((sender, ctx) -> { /* ... */ })
     .build();
 ```
 
@@ -544,7 +545,7 @@ SlashCommand transfer = SlashCommand.create("transfer")
     .argInt("amount").optional(true)
     .flag("all", 'a', "all")
     .crossValidate(CrossArgumentValidator.mutuallyExclusive("amount", "all"))
-    .executes(ctx -> { /* ... */ })
+    .executes((sender, ctx) -> { /* ... */ })
     .build();
 
 // With custom error message
@@ -564,7 +565,7 @@ SlashCommand dateRange = SlashCommand.create("daterange")
     .argString("startDate").optional(true)
     .argString("endDate").optional(true)
     .crossValidate(CrossArgumentValidator.requiresAll("startDate", "endDate"))
-    .executes(ctx -> { /* ... */ })
+    .executes((sender, ctx) -> { /* ... */ })
     .build();
 ```
 
@@ -577,7 +578,7 @@ SlashCommand target = SlashCommand.create("target")
     .argPlayer("player").optional(true)
     .argString("coords").optional(true)
     .crossValidate(CrossArgumentValidator.requiresAny("player", "coords"))
-    .executes(ctx -> { /* ... */ })
+    .executes((sender, ctx) -> { /* ... */ })
     .build();
 ```
 
@@ -590,7 +591,7 @@ SlashCommand export = SlashCommand.create("export")
     .argString("output").optional(true)
     .argString("format").optional(true)
     .crossValidate(CrossArgumentValidator.requiresIfPresent("output", "format"))
-    .executes(ctx -> { /* ... */ })
+    .executes((sender, ctx) -> { /* ... */ })
     .build();
 
 // With custom message
@@ -611,7 +612,7 @@ SlashCommand range = SlashCommand.create("range")
     .argInt("min")
     .argInt("max")
     .crossValidate(CrossArgumentValidator.range("min", "max"))
-    .executes(ctx -> { /* ... */ })
+    .executes((sender, ctx) -> { /* ... */ })
     .build();
 
 // With custom message
@@ -634,7 +635,7 @@ SlashCommand dates = SlashCommand.create("dates")
         (start, end) -> start.compareTo(end) <= 0,
         "Start date must be before end date",
         String.class))
-    .executes(ctx -> { /* ... */ })
+    .executes((sender, ctx) -> { /* ... */ })
     .build();
 ```
 
@@ -649,7 +650,7 @@ SlashCommand trade = SlashCommand.create("trade")
         ctx -> ctx.getFlag("premium"),
         "Premium members must provide a verification code",
         "verificationCode"))
-    .executes(ctx -> { /* ... */ })
+    .executes((sender, ctx) -> { /* ... */ })
     .build();
 ```
 
@@ -664,7 +665,7 @@ SlashCommand complex = SlashCommand.create("complex")
         CrossArgumentValidator.requiresAny("player", "all"),
         CrossArgumentValidator.range("min", "max")
     ))
-    .executes(ctx -> { /* ... */ })
+    .executes((sender, ctx) -> { /* ... */ })
     .build();
 ```
 
@@ -683,7 +684,7 @@ SlashCommand export = SlashCommand.create("export")
     .argString("output-file").optional(true)
     // "output-file" can only be used if "save" flag is present
     .crossValidate(CrossArgumentValidator.dependsOn("output-file", "save"))
-    .executes(ctx -> { /* ... */ })
+    .executes((sender, ctx) -> { /* ... */ })
     .build();
 
 // With custom error message
@@ -702,7 +703,7 @@ SlashCommand cmd = SlashCommand.create("cmd")
     .argString("config")
     // "advanced-settings" requires both "mode" AND "config"
     .crossValidate(CrossArgumentValidator.dependsOnAll("advanced-settings", "mode", "config"))
-    .executes(ctx -> { /* ... */ })
+    .executes((sender, ctx) -> { /* ... */ })
     .build();
 ```
 
@@ -717,7 +718,7 @@ SlashCommand cmd = SlashCommand.create("cmd")
     .flagLong("save", "save")
     // "format" requires either "export" OR "save" (or both)
     .crossValidate(CrossArgumentValidator.dependsOnAny("format", "export", "save"))
-    .executes(ctx -> { /* ... */ })
+    .executes((sender, ctx) -> { /* ... */ })
     .build();
 ```
 
@@ -731,7 +732,7 @@ SlashCommand cmd = SlashCommand.create("cmd")
     .flagLong("quiet", "quiet")
     // "verbose" cannot be used when "quiet" is present
     .crossValidate(CrossArgumentValidator.excludedBy("verbose", "quiet"))
-    .executes(ctx -> { /* ... */ })
+    .executes((sender, ctx) -> { /* ... */ })
     .build();
 
 // Note: For two-way exclusion, use mutuallyExclusive() instead
@@ -747,7 +748,7 @@ SlashCommand cmd = SlashCommand.create("cmd")
     .flagLong("use-defaults", "use-defaults")
     // "config" is required UNLESS "use-defaults" is specified
     .crossValidate(CrossArgumentValidator.requiredUnless("config", "use-defaults"))
-    .executes(ctx -> { /* ... */ })
+    .executes((sender, ctx) -> { /* ... */ })
     .build();
 ```
 
@@ -761,7 +762,7 @@ SlashCommand login = SlashCommand.create("login")
     .argString("password").optional(true)
     // Both "username" and "password" must be provided together
     .crossValidate(CrossArgumentValidator.coDependent("username", "password"))
-    .executes(ctx -> { /* ... */ })
+    .executes((sender, ctx) -> { /* ... */ })
     .build();
 ```
 
@@ -775,7 +776,7 @@ SlashCommand admin = SlashCommand.create("admin")
     .flagLong("admin-action", "admin-action")
     // "level" must be "admin" when "admin-action" is used
     .crossValidate(CrossArgumentValidator.valueRequiredWhen("level", "admin", "admin-action"))
-    .executes(ctx -> { /* ... */ })
+    .executes((sender, ctx) -> { /* ... */ })
     .build();
 ```
 
@@ -790,7 +791,7 @@ SlashCommand workflow = SlashCommand.create("workflow")
     .argString("step3").optional(true)
     // step3 requires step2, step2 requires step1
     .crossValidate(CrossArgumentValidator.dependencyChain("step1", "step2", "step3"))
-    .executes(ctx -> { /* ... */ })
+    .executes((sender, ctx) -> { /* ... */ })
     .build();
 
 // Valid:   /workflow step1=a

--- a/wiki/Help-TabCompletion.md
+++ b/wiki/Help-TabCompletion.md
@@ -15,7 +15,7 @@ SlashCommand cmd = SlashCommand.create("example")
     .argInt("age")
     .flagLong("verbose", "verbose")
     .keyValueInt("limit", 25)
-    .executes(ctx -> { /* ... */ })
+    .executes((sender, ctx) -> { /* ... */ })
     .build();
 
 String usage = cmd.usage();
@@ -56,7 +56,7 @@ SlashCommand find = SlashCommand.create("find")
     .argStringWithCompletions("type", "user", "world", "item")
     .keyValueInt("limit", 25)
     .flagLong("exact", "exact")
-    .executes(ctx -> { /* ... */ })
+    .executes((sender, ctx) -> { /* ... */ })
     .build();
 ```
 

--- a/wiki/Interactive-Prompting.md
+++ b/wiki/Interactive-Prompting.md
@@ -47,10 +47,10 @@ Or using the fluent Arg API:
 
 ```java
 SlashCommand cmd = SlashCommand.create("give")
-    .arg(Arg.of("player", ArgParsers.PLAYER)
+    .arg(new Arg<>("player", ArgParsers.PLAYER)
         .interactive(true)
         .withDescription("The recipient"))
-    .arg(Arg.of("item", ArgParsers.MATERIAL)
+    .arg(new Arg<>("item", ArgParsers.MATERIAL)
         .interactive(true)
         .withDescription("The item to give"))
     .executes((sender, ctx) -> { /* ... */ })
@@ -92,8 +92,8 @@ boolean active = InteractivePrompt.hasActiveSession(player);
 // Get the current session
 PromptSession session = InteractivePrompt.getSession(player);
 
-// Cancel a session programmatically
-InteractivePrompt.cancelSession(player);
+// Cancel a session programmatically (returns boolean indicating if a session was active)
+boolean cancelled = InteractivePrompt.cancelSession(player);
 
 // Clean up when player disconnects
 InteractivePrompt.cleanupPlayer(player);

--- a/wiki/Pagination.md
+++ b/wiki/Pagination.md
@@ -59,7 +59,7 @@ Combine with `argPage()` and `argPage(name, defaultPage)` to parse the desired p
 ```java
 SlashCommand listHomes = SlashCommand.create("listhomes")
     .argPage("page", 1)
-    .executes(ctx -> {
+    .executes((sender, ctx) -> {
         int page = ctx.get("page", Integer.class);
         PaginationDataSource<Home> ds = new ListDataSource<>(homeService.list(ctx));
         PaginatedResult<Home> result = ds.page(page, 10);

--- a/wiki/Parsing-API.md
+++ b/wiki/Parsing-API.md
@@ -1205,13 +1205,12 @@ SlashCommand.builder("give")
         .build())
     .build();
 
-// Using Arg fluent API
-Arg<Player> playerArg = Arg.of("player", playerParser())
-    .withAliases("p", "target", "t");
+// Using Arg with aliases
+Arg<Player> playerArg = new Arg<>("player", playerParser(),
+        ArgContext.builder().aliases("p", "target", "t").build());
 
-Arg<Integer> amountArg = Arg.of("amount", intParser())
-    .withAlias("amt")
-    .withAlias("n");
+Arg<Integer> amountArg = new Arg<>("amount", intParser(),
+        ArgContext.builder().aliases("amt", "n").build());
 ```
 
 ### Using Aliases in CommandContext

--- a/wiki/Performance-Optimization.md
+++ b/wiki/Performance-Optimization.md
@@ -102,7 +102,7 @@ List<String> worlds = ArgumentCache.getWorldNames();
 List<String> materials = ArgumentCache.getMaterialNames();
 
 // Filter by prefix (for tab completion)
-List<String> filtered = ArgumentCache.getPlayerNames("No");  // Notch, NoobMaster, etc.
+List<String> filtered = ArgumentCache.getPlayerNamesStartingWith("No");  // Notch, NoobMaster, etc.
 ```
 
 ### Custom Caching
@@ -122,15 +122,14 @@ boolean cached = ArgumentCache.isCached("expensive-key");
 ArgumentCache.invalidate("expensive-key");
 
 // Clear all custom caches
-ArgumentCache.clearCustomCaches();
+ArgumentCache.clearAll();
 ```
 
 ### Typed Caches
 
 ```java
 // Create a typed cache for specific data
-ArgumentCache.TypedCache<List<String>> homeCache = ArgumentCache.typed(
-    "homes",
+ArgumentCache.TypedCache<List<String>> homeCache = ArgumentCache.createTypedCache(
     5, TimeUnit.MINUTES
 );
 
@@ -377,12 +376,8 @@ ResultCache cache = ResultCache.create(5, TimeUnit.MINUTES);
 // With max size
 ResultCache cache = ResultCache.create(5, TimeUnit.MINUTES, 1000);
 
-// Full configuration
-ResultCache cache = ResultCache.builder()
-    .ttl(5, TimeUnit.MINUTES)
-    .maxSize(1000)
-    .evictionPolicy(EvictionPolicy.LRU)
-    .build();
+// Full configuration (using factory method)
+ResultCache cache = ResultCache.create(5, TimeUnit.MINUTES, 1000);
 ```
 
 ### Caching Results
@@ -404,10 +399,11 @@ Object result = cache.getOrCompute(key, () -> computePlayerStats(playerName));
 ### Sender-Specific Caching
 
 ```java
-// Per-sender results
-Object result = cache.getOrComputeForSender(
-    sender,
-    "personal-stats",
+// Per-sender results (use the 4-parameter getOrCompute overload)
+Object result = cache.getOrCompute(
+    "stats",           // commandName
+    context,           // CommandContext
+    sender,            // CommandSender
     () -> computePersonalStats(sender)
 );
 
@@ -456,7 +452,7 @@ ObjectPool<StringBuilder> sbPool = perf.getStringBuilderPool();
 ObjectPool<ArrayList<?>> listPool = perf.getArrayListPool();
 
 // Caches
-ArgumentCache argCache = perf.getArgumentCache();
+// Note: ArgumentCache is a static utility — use ArgumentCache.getPlayerNames() etc. directly
 ResultCache resultCache = perf.getResultCache();
 
 // Parsers
@@ -469,33 +465,18 @@ ParallelParser parallelParser = perf.getParallelParser();
 PerformanceManager.PerformanceStats stats = perf.getStats();
 
 // Pool stats
-long poolBorrowed = stats.totalPoolBorrowed();
-long poolReused = stats.totalPoolReused();
-double poolReuseRate = stats.poolReuseRate();
+ObjectPool.PoolStats poolStats = stats.getStringBuilderPoolStats();
 
 // Cache stats
-long cacheHits = stats.totalCacheHits();
-long cacheMisses = stats.totalCacheMisses();
-double cacheHitRate = stats.cacheHitRate();
+ResultCache.Stats cacheStats = stats.getResultCacheStats();
 
 // Parse stats
-long argsParsed = stats.totalArgumentsParsed();
-double avgParseTime = stats.averageParseTimeNanos();
+ParallelParser.Stats parseStats = stats.getParallelParserStats();
 ```
 
 ### Configuration
 
-```java
-// Configure at startup
-PerformanceManager.configure(config -> config
-    .stringBuilderPoolSize(100)
-    .arrayListPoolSize(50)
-    .resultCacheTTL(10, TimeUnit.MINUTES)
-    .resultCacheMaxSize(500)
-    .parallelParserThreads(4)
-    .parallelThreshold(3)
-);
-```
+> **Note:** `PerformanceManager.configure(config -> ...)` does not exist. Configure each component individually at creation time (e.g., `ObjectPool.create(...)`, `ResultCache.create(...)`, `ParallelParser.builder()...build()`).
 
 ---
 
@@ -587,7 +568,7 @@ All classes in this package are thread-safe:
 | `getMaterialNames()` | Get cached material names |
 | `getOrCompute(key, supplier, ttl, unit)` | Cache custom value |
 | `invalidate(key)` | Remove cached entry |
-| `typed(prefix, ttl, unit)` | Create typed cache |
+| `createTypedCache(ttl, unit)` | Create typed cache |
 | `getStats()` | Get cache statistics |
 
 ### LazyArgument
@@ -626,7 +607,7 @@ All classes in this package are thread-safe:
 | `create(ttl, unit)` | Create with TTL |
 | `create(ttl, unit, maxSize)` | Create with TTL and max size |
 | `getOrCompute(key, supplier)` | Get or compute value |
-| `getOrComputeForSender(sender, key, supplier)` | Per-sender caching |
+| `getOrCompute(commandName, context, sender, supplier)` | Per-sender caching |
 | `invalidate(key)` | Remove entry |
 | `invalidateForSender(sender)` | Remove sender entries |
 | `clear()` | Clear all entries |
@@ -640,8 +621,8 @@ All classes in this package are thread-safe:
 | `getInstance()` | Get singleton |
 | `getStringBuilderPool()` | Get StringBuilder pool |
 | `getArrayListPool()` | Get ArrayList pool |
-| `getArgumentCache()` | Get argument cache |
+| _(ArgumentCache is a static utility)_ | Use `ArgumentCache.getPlayerNames()` etc. directly |
 | `getResultCache()` | Get result cache |
 | `getParallelParser()` | Get parallel parser |
 | `getStats()` | Get combined statistics |
-| `configure(config)` | Configure defaults |
+| _(no configure method)_ | Configure components individually at creation time |

--- a/wiki/SlashCommand-Overview.md
+++ b/wiki/SlashCommand-Overview.md
@@ -26,8 +26,7 @@ This page introduces the Leviathan SlashCommand system: the architecture, lifecy
 ```java
 SlashCommand ping = SlashCommand.create("ping")
     .description("Simple latency check")
-    .executes(ctx -> {
-        CommandSender sender = ctx.get("sender", CommandSender.class);
+    .executes((sender, ctx) -> {
         sender.sendMessage("Pong!");
     })
     .build();
@@ -42,10 +41,10 @@ Attach hierarchical subcommands to create powerful command trees:
 ```java
 SlashCommand mathAdd = SlashCommand.create("add")
     .argInt("a").argInt("b")
-    .executes(ctx -> {
+    .executes((sender, ctx) -> {
         int a = ctx.get("a", Integer.class);
         int b = ctx.get("b", Integer.class);
-        ctx.get("sender", CommandSender.class).sendMessage("= " + (a + b));
+        sender.sendMessage("= " + (a + b));
     })
     .build();
 

--- a/wiki/Wizard-System.md
+++ b/wiki/Wizard-System.md
@@ -79,14 +79,14 @@ Collect typed input from the user:
 Execute code and continue to another node:
 
 ```java
-.action("validate", ctx -> {
+.node(WizardNode.action("validate", ctx -> {
     // Perform validation or intermediate processing
     int amount = ctx.getInt("amount", 1);
     if (amount > 64) {
         ctx.player().sendMessage("Amount too high, setting to 64.");
-        ctx.put("amount", 64);
+        ctx.set("amount", 64);
     }
-}, "next-step")
+}).nextNode("next-step").build())
 ```
 
 ##### Terminal Nodes
@@ -157,10 +157,10 @@ The `WizardContext` provides access to collected data and navigation:
     }
 
     // Get the path taken through the wizard
-    List<String> path = ctx.navigationHistory();
+    List<String> path = ctx.navigationPath();
 
     // Get all choices made
-    Map<String, String> choices = ctx.choices();
+    List<WizardChoice> choices = ctx.choices();
 
     // Access the original command context
     CommandContext cmdCtx = ctx.commandContext();
@@ -209,7 +209,7 @@ Skip nodes based on previous answers:
     .option("diamond", "Diamond Armor", "enchant")
     .option("iron", "Iron Armor", "enchant")
     .option("none", "No Armor", "weapons")  // Skip enchant step
-    .skipIf(ctx -> ctx.getString("type", "").equals("utility"))
+    .skipWhen(ctx -> ctx.getString("type", "").equals("utility"))
 )
 ```
 
@@ -219,7 +219,7 @@ Configure session timeout:
 
 ```java
 WizardDefinition wizard = WizardDefinition.builder("setup")
-    .timeout(Duration.ofMinutes(5))  // Session expires after 5 minutes
+    .timeout(5, TimeUnit.MINUTES)  // Session expires after 5 minutes
     .timeoutMessage("Session expired. Please start again.")
     // ... nodes
     .build();
@@ -269,7 +269,7 @@ public void onQuit(PlayerQuitEvent event) {
 ```java
 WizardDefinition warpWizard = WizardDefinition.builder("create-warp")
     .description("Create a new warp point")
-    .timeout(Duration.ofMinutes(3))
+    .timeout(3, TimeUnit.MINUTES)
 
     // Step 1: Enter warp name
     .input("name", "warpName", "Enter the warp name:", ArgParsers.stringParser(), "visibility")


### PR DESCRIPTION
Systematic comparison of all 20 wiki files against the actual source code revealed 40 discrepancies (7 critical, 22 high, 8 medium, 3 low).

Global fixes across 17 wiki files:
- Fix all executes(ctx -> {...}) to executes((sender, ctx) -> {...}) to match CommandAction's two-parameter signature
- Fix all ctx.get("sender", ...) to use the sender lambda parameter directly (sender is NOT stored in CommandContext)

SlashCommand-Overview.md:
- Fix minimal example and subcommand example lambda signatures

Builder-API.md:
- Fix executes examples, add note about CommandMetrics not being wired into builder API, clarify register() is on SlashCommand not builder

Arguments.md:
- Replace non-existent Arg.of() with correct constructor form
- Fix fluent chain .argPlayer().withDescription() (returns builder, not Arg)
- Qualify Validator<T> as ArgContext.Validator<T>

Async-Cooldowns.md:
- Fix executesAsync lambda: (ctx, progress, cancellation) ->
  (sender, ctx, token, progress) with correct parameter order
- Fix cancellation.isCancelled() -> token.cancelled()
- Fix progress.set(percent) -> progress.report(String)

Guards-Validation-Permissions.md:
- Fix CrossArgumentValidator example: throws exception -> returns String

Batch-Operations.md:
- Fix .timeout(30_000) -> .timeoutMillis(30_000)
- Fix .maxParallelism(4) -> .parallelism(4)
- Fix defaults: showProgress true (not false), timeout 30000 (not 60000)

Exceptions-ErrorHandling.md:
- Fix default similarity threshold: 0.4 (not 0.6)

Wizard-System.md:
- Fix .timeout(Duration) -> .timeout(long, TimeUnit)
- Fix non-existent .action() builder method
- Fix ctx.put() -> ctx.set()
- Fix ctx.navigationHistory() -> ctx.navigationPath()
- Fix ctx.choices() return type: List<WizardChoice> not Map<String,String>
- Fix .skipIf() -> .skipWhen()

Performance-Optimization.md:
- Fix 8+ wrong method names (getPlayerNames->getPlayerNamesStartingWith, typed->createTypedCache, ResultCache.builder->ResultCache.create, etc.)
- Fix PerformanceManager API (getArgumentCache/configure don't exist)
- Fix stats accessor names to match actual getter-style API

Advanced-Completions.md:
- Fix DynamicCompletionContext.getParsedArgument() -> parsedArgsSoFar().get()

Interactive-Prompting.md:
- Fix Arg.of() -> correct constructor, cancelSession() returns boolean

Examples.md:
- Fix all 8 code examples with correct lambda signatures
- Fix progress.set(i) -> progress.report(String)
- Fix token.isCancelled() -> token.cancelled()

Parsing-API.md, CommandContext-API.md:
- Fix Arg.of() -> constructor with ArgContext for aliases

Flags-KeyValues.md, Help-TabCompletion.md, Pagination.md:
- Fix executes lambda signatures

https://claude.ai/code/session_01G2ueeVbU7bpWiS67t5Aae7